### PR TITLE
build(build): rotate updater signing keypair and clean up artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Rotate updater signing keypair and update public key in Tauri config to fix incorrect private key password error during builds
 - Add `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` to publish workflow for signing updater artifacts
 - Add `updaterJsonPreferNsis` to publish workflow for Windows NSIS installer preference in `latest.json`
 - Add `updater:default` and `process:allow-restart` permissions to Tauri capabilities

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDJBNDlCRkE4ODA2MzNDMEQKUldRTlBHT0FxTDlKS3BkQXVLVlB4clRwTS9rME9wUnoybnR4Nnl5S2hiYXBKNUhvSjBRV1YvYWQK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDgyNDhBMkIwNTgzMEZDRDkKUldUWi9EQllzS0pJZ21wV2JqWU1lUi9vZFZUMFNYWUlEWXlMdjJUSFZtaEsxb1p1LzNkNk84YU0K",
       "endpoints": [
         "https://github.com/HopeADeff/hope-re/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
Replace the Tauri updater public key with a newly generated keypair to fix incorrect private key password error during CI builds. Remove stray nul file from the repository.
