### PR TITLE
fix(build): bump version to 2.1.0 to fix auto-updater for v2.0.77 users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [2.0.8] - 2026-03-01
+## [2.1.0] - 2026-03-01
+
+### Fixed
+
+- Fix version numbering scheme so auto-updater correctly detects new releases for users on v2.0.77 and earlier (semver: 2.0.77 > 2.0.8, so those users could never update)
 
 ### Performance
 
@@ -306,6 +310,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Update SvelteKit and Svelte packages to avoid CVE from older versions ([#20](https://github.com/HopeArtOrg/hope-re/pull/20))
 
+[2.1.0]: https://github.com/HopeArtOrg/hope-re/compare/v2.0.8...v2.1.0
 [2.0.8]: https://github.com/HopeArtOrg/hope-re/compare/v2.0.77...v2.0.8
 [2.0.77]: https://github.com/HopeArtOrg/hope-re/compare/v2.0.76...v2.0.77
 [2.0.76]: https://github.com/HopeArtOrg/hope-re/compare/v2.0.75...v2.0.76

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-re",
   "type": "module",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-ad"
-version = "2.0.8"
+version = "2.1.0"
 description = "An AI-proofing arts app"
 authors = [ "HopeArtOrg" ]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope-RE",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "identifier": "com.HopeArtOrg.hope-re",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
The Tauri updater uses semver comparison where patch numbers are compared numerically (77 > 8), so users on v2.0.77 could never detect v2.0.8 as a newer release. Bumping to v2.1.0 ensures the minor version comparison (1 > 0) correctly identifies the update for all prior versions.
